### PR TITLE
Custom run assembler path

### DIFF
--- a/src/main/groovy/com/epam/atg/gradle/ATGPluginConstants.groovy
+++ b/src/main/groovy/com/epam/atg/gradle/ATGPluginConstants.groovy
@@ -24,7 +24,7 @@ class ATGPluginConstants {
     static final String PROJECT_ATG_REPOSITORY_PROPERTY = 'atgRepository'
     static final String PROJECT_SETTINGS_EXCLUDE_MODULES = 'excludedAtgProjects'
 
-    static final String ATG_RUN_ASSEMBLER_ABSOLUTE_PATH = 'runAssemblerDir'
+    static final String ATG_RUN_ASSEMBLER_ABSOLUTE_PATH = 'runAssemblerPath'
 
     static final String ATG_TASK_GROUP = 'atg'
     static final String ATG_PLUGIN_EXTENSION_NAME = 'atg'

--- a/src/main/groovy/com/epam/atg/gradle/ATGPluginConstants.groovy
+++ b/src/main/groovy/com/epam/atg/gradle/ATGPluginConstants.groovy
@@ -24,6 +24,8 @@ class ATGPluginConstants {
     static final String PROJECT_ATG_REPOSITORY_PROPERTY = 'atgRepository'
     static final String PROJECT_SETTINGS_EXCLUDE_MODULES = 'excludedAtgProjects'
 
+    static final String ATG_RUN_ASSEMBLER_ABSOLUTE_PATH = 'runAssemblerDir'
+
     static final String ATG_TASK_GROUP = 'atg'
     static final String ATG_PLUGIN_EXTENSION_NAME = 'atg'
 

--- a/src/main/groovy/com/epam/atg/gradle/assemble/AssembleATGTask.groovy
+++ b/src/main/groovy/com/epam/atg/gradle/assemble/AssembleATGTask.groovy
@@ -22,6 +22,7 @@ import com.epam.atg.gradle.utils.ProjectUtils
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils
 
 /**
  * ATG Assembler EAR
@@ -74,7 +75,7 @@ class AssembleATGTask extends DefaultTask {
 
         project.ant.taskdef(name: 'assembleEAR',
                 classname: 'atg.appassembly.ant.CreateUnpackedEarTask',
-                classpath: "$dynamoRoot/home/lib/assembler.jar")
+                classpath: "${getRunAssemblerPath()}")
 
         Map assemblerEARTaskParameters = [
                 //required
@@ -117,6 +118,15 @@ class AssembleATGTask extends DefaultTask {
                 link.delete()
                 project.logger.info('Removed temporary link {}', link)
             }
+        }
+    }
+
+    private String getRunAssemblerPath() {
+        String runAssemblerDir = project.property(ATGPluginConstants.ATG_RUN_ASSEMBLER_ABSOLUTE_PATH)
+        if (StringUtils.isNotEmpty(runAssemblerDir)) {
+            return runAssemblerDir
+        } else {
+            return "$dynamoRoot/home/lib/assembler.jar"
         }
     }
 }


### PR DESCRIPTION
Added method to get either custom path to assembler.jar or get default from $dynamoRoot.
Renamed project property to avoid misunderstanding - property should contain absolutePath with jar file name.